### PR TITLE
[BUG] add warning in game when one life is left and improve ui 

### DIFF
--- a/Alien.css
+++ b/Alien.css
@@ -28,6 +28,60 @@ body {
   backdrop-filter: blur(8px);
 }
 
+.gameProgress {
+  display: flex;
+  justify-content: space-evenly; /* Spacing between liveScore and liveLife */
+  align-items: center;
+  padding: 10px;
+  color: #fff;
+  font-size: 25px;
+  text-align: center;
+  width: 100%;
+}
+
+#liveScore,
+#liveLife {
+  margin: 5px 0;
+}
+
+#score {
+  color: yellow;
+  font-weight: 800;
+}
+#lives {
+  color: red;
+  font-weight: 800;
+}
+
+#warningMessage {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 36px;
+  color: red;
+  font-weight: bold;
+  text-align: center;
+  animation: blink 1s ease-in-out 1; /* Runs for 1 second, and only once */
+  z-index: 1000;
+  display: none;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+.hidden {
+  display: none;
+}
+
+
 #gameControls {
   position: absolute;
   left: 20px; /* Adjust this value to position controls on the left */
@@ -872,36 +926,7 @@ input:checked + .slider:before {
   width: 150px;
 }
 
-#liveScore {
-  position: absolute;
-  top: 10px;
-  left: 134px;
-  font-size: 20px;
-  font-weight: bold;
-  color: white;
-}
-#liveLife {
-  position: absolute;
-  top: 42px;
-  left: 134px;
-  font-size: 20px;
-  font-weight: bold;
-  color: white;
-}
 
-
-
-
-.sidebar {
-  background-color: grey;
-  height: 100%;
-  gap: 10px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 16px;
-}
 /*---------------------*/
 
 .controls{

--- a/Alien.js
+++ b/Alien.js
@@ -456,7 +456,16 @@ function update() {
       aliens.splice(alienIndex, 1);
       lives--;
       livesElement.textContent = lives;
-      if (lives <= 0) gameOver();
+      if (lives === 1) {
+        // Show the warning message
+        const warningMessage = document.getElementById("warningMessage");
+        warningMessage.style.display = "block"; // Show the message
+
+        // Hide the warning after 1 seconds
+        setTimeout(() => {
+          warningMessage.style.display = "none";
+        }, 1000);
+      } else if (lives <= 0) gameOver();
     }
 
     if (
@@ -469,6 +478,16 @@ function update() {
       livesElement.textContent = lives;
       aliens.splice(alienIndex, 1);
       if (lives <= 0) gameOver();
+      else if (lives === 1) {
+        // Show the warning message
+        const warningMessage = document.getElementById("warningMessage");
+        warningMessage.style.display = "block"; // Show the message
+
+        // Hide the warning after 1 seconds
+        setTimeout(() => {
+          warningMessage.style.display = "none";
+        }, 1000);
+      }
     }
 
     bullets.forEach((bullet, bulletIndex) => {

--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@
 <body>
     <div id="gameContainer">
         <canvas id="gameCanvas"></canvas>
+        <div class="gameProgress">
+            <div id="warningMessage" class="hidden">Only 1 life remaining!</div>
+            <div id="liveScore">LIVE SCORE: <span id="score">0</span></div>
+            <div id="liveLife">LIVE LIFE: <span id="lives">3</span></div>
+        </div>
         <div id="gameControls">
             <div class="controlGroup">
                 <label for="levelSelect" id="difficulty">Select Difficulty:</label>
@@ -98,18 +103,14 @@
     <!-- Snowflakes div omitted for brevity -->
     
     <div id="header">
-        <div class="sidebar">
-            <div id="liveScore">LIVE SCORE: <span id="score">0</span></div> 
-            <div id="liveLife">LIVE LIFE: <span id="lives">3</span></div>
-            <div id="gameInfo">
-                <i class="fas fa-star"></i> <span id="score">0</span> | 
-                <i class="fas fa-level-up-alt"></i> <span id="level">1</span> | 
-                <i class="fas fa-heart"></i> <span id="lives">3</span>
-                <!-- New span elements to display power-up timers -->  
-                <span id="healthBoostTimer"></span>  
-                <span id="speedBoostTimer"></span>  
-                <span id="shieldTimer"></span>  
-            </div>
+        <div id="gameInfo">
+            <i class="fas fa-star"></i> <span id="score">0</span> | 
+            <i class="fas fa-level-up-alt"></i> <span id="level">1</span> | 
+            <i class="fas fa-heart"></i> <span id="lives">3</span>
+            <!-- New span elements to display power-up timers -->  
+            <span id="healthBoostTimer"></span>  
+            <span id="speedBoostTimer"></span>  
+            <span id="shieldTimer"></span>  
         </div>
         
         <div id="instructions">


### PR DESCRIPTION
## What does this PR do?

this PR puts up a live warning message when the player only has 1 life remaining. It also puts the LIVE SCORE & LIVE LIFE options under the game screen/canvas and improves the count shown by them so user is more easily able to see their performance.

Fixes #239 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
https://github.com/user-attachments/assets/3567ee01-9cea-4b3f-829e-dac0410bbacc


## Type of change
<!-- Please delete bullets that are not relevant. -->
- New feature (non-breaking change which adds functionality)


## How should this be tested?

- [X] Test A
- [X] Test B

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.