### PR TITLE
align the page section on right correctly #298

### DIFF
--- a/Alien.css
+++ b/Alien.css
@@ -211,14 +211,13 @@ button{
   z-index: 10;
 }
 
+
 #instructions {
   position: absolute;
-  top: 100px;
-  font-size: medium;
-  width: 200px;
-  padding: 10px;
-  font-weight: 700;
-  text-decoration: solid;
+  right: 0;
+  top: 20px;
+  width: 300px;
+  padding: 20px;
 }
 
 #instructionsList {
@@ -952,6 +951,10 @@ input:checked + .slider:before {
   color: orange;
   font-size: xx-large;
   width: 100%;
+}
+
+#musicVolumeText {
+  color: white;
 }
 
 #volumeControl {

--- a/index.html
+++ b/index.html
@@ -146,7 +146,8 @@
                 <div id="volumeControl">
                     <div id="muteControl">
                         <button id="muteButton" class="styled-button">
-                            <i class="fas fa-volume-up"></i> Music Volume
+                            <i class="fas fa-volume-up"></i> 
+                            <p id="musicVolumeText">Music Volume</p>
                         </button>
                         
                     </div>


### PR DESCRIPTION
## What does this PR do?
The section consisting of light mode toggle, signup/register, instructions etc. has been aligned correctly to the right side of web page so that the website looks more responsive.
Also the color of text music Volume is white now which makes its visibility better.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #298 

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
before:
![image](https://github.com/user-attachments/assets/9f3e9450-574a-4632-ab23-6b6c832d411f)

after:
![image](https://github.com/user-attachments/assets/7d0ecfab-c91b-48e6-8360-0e4928b75986)


## Type of change

<!-- Please delete bullets that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [X] Test A
- [X] Test B

## Mandatory Tasks

- [X] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.