### PR TITLE
Fix Newsletter Popup Reappearance After User Dismissal

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -8,6 +8,10 @@ window.onload = function() {
     document.getElementById('popup-nl').style.display = 'none';
   });
 
+  if (localStorage.getItem("noThanksClicked") === "true") {
+    document.getElementById('popup-nl').style.visibility = 'hidden';
+  }
+
   // // Close the pop-up when clicking outside the pop-up content
   // window.addEventListener('click', function(event) {
   //   const popupContent = document.querySelector('.popup-content'); // Select the popup content
@@ -31,4 +35,5 @@ window.onload = function() {
   document.querySelector('.no-thanks-nl').addEventListener('click', function(event) {
     event.preventDefault();
     document.getElementById('popup-nl').style.display = 'none';
+    localStorage.setItem("noThanksClicked", "true");
   });


### PR DESCRIPTION
# Title: Fix Newsletter Popup Reappearance After User Dismissal

## Description

Fix #667 

This PR resolves the issue of the newsletter popup reappearing after clicking **"No Thanks"** by implementing a dismissal flag in cookies/local storage. The popup now checks this flag before displaying, enhancing the user experience by preventing unnecessary prompts.

@YadavAkhileshh 
Pls assign me this, Give me label, level.