### PR TITLE
fix: wrap localStorage access in try-catch and fix flash effect coordinates

### DIFF
--- a/game/alien-defense-engine.js
+++ b/game/alien-defense-engine.js
@@ -35,13 +35,20 @@ const CONFIG = {
 // =========================================
 // 2. GAME STATE
 // =========================================
+let savedHighScore = 0;
+try {
+  savedHighScore = parseInt(localStorage.getItem('alienDefenseHighScore')) || 0;
+} catch {
+  // localStorage may not be available in some contexts
+}
+
 const gameState = {
   active: false,
   paused: false,
   score: 0,
 
   lives: 3,
-  highScore: parseInt(localStorage.getItem('alienDefenseHighScore')) || 0,
+  highScore: savedHighScore,
   difficulty: 'medium',
   player: null,
   aliens: [],

--- a/game/game-patch.js
+++ b/game/game-patch.js
@@ -41,8 +41,9 @@
                 flash.style.height = '10px';
                 flash.style.background = '#0ff';
                 flash.style.borderRadius = '50%';
-                flash.style.left = e.clientX + 'px';
-                flash.style.top = e.clientY + 'px';
+                const rect = canvas.getBoundingClientRect();
+                flash.style.left = (e.clientX - rect.left) + 'px';
+                flash.style.top = (e.clientY - rect.top) + 'px';
                 flash.style.pointerEvents = 'none';
                 flash.style.boxShadow = '0 0 20px #0ff';
                 flash.style.animation = 'fadeOut 0.3s ease-out forwards';


### PR DESCRIPTION
**Fixes**:

1. **`game/alien-defense-engine.js`**: Wrapped `localStorage.getItem()` call at module level in a try-catch. Previously, if `localStorage` was unavailable (private browsing/SSR), the script would throw at parse time and never load.

2. **`game/game-patch.js`**: Fixed flash effect coordinates to use `getBoundingClientRect()` offset instead of raw viewport coordinates. The flash element uses `position: absolute`, so `clientX/clientY` (viewport-relative) would place it incorrectly when the page is scrolled.