### PR TITLE
fix: prevent warning timeout leak on game restart

### DIFF
--- a/game/alien-defense-engine.js
+++ b/game/alien-defense-engine.js
@@ -419,6 +419,7 @@ function resetGameState() {
   gameState.bullets = [];
   gameState.particles = [];
   gameState.paused = false;
+  clearTimeout(warningTimeout);
   updateUI();
 }
 
@@ -582,10 +583,13 @@ function loseLife() {
   }
 }
 
+let warningTimeout = null;
+
 function showWarning() {
   if (DOM.warningMessage) {
     DOM.warningMessage.classList.remove('hidden');
-    setTimeout(() => {
+    clearTimeout(warningTimeout);
+    warningTimeout = setTimeout(() => {
       DOM.warningMessage.classList.add('hidden');
     }, 2000);
   }


### PR DESCRIPTION
Fixed showWarning() timeout not being cleared on game restart, which could cause warning message to hide mid-game or leak across restarts. Added warningTimeout tracking and clearTimeout in resetGameState().