### PR TITLE
fix: wrap localStorage access in try-catch to prevent crash in restricted environments

### DIFF
--- a/game/alien-defense-engine.js
+++ b/game/alien-defense-engine.js
@@ -35,13 +35,20 @@ const CONFIG = {
 // =========================================
 // 2. GAME STATE
 // =========================================
+let savedHighScore = 0;
+try {
+  savedHighScore = parseInt(localStorage.getItem('alienDefenseHighScore')) || 0;
+} catch (e) {
+  // localStorage unavailable (sandboxed iframe, private browsing, etc.)
+}
+
 const gameState = {
   active: false,
   paused: false,
   score: 0,
 
   lives: 3,
-  highScore: parseInt(localStorage.getItem('alienDefenseHighScore')) || 0,
+  highScore: savedHighScore,
   difficulty: 'medium',
   player: null,
   aliens: [],


### PR DESCRIPTION
The `gameState` object called `localStorage.getItem(...)` at module-initialisation time. In environments where `localStorage` is unavailable (sandboxed iframes, restricted browsing modes, some mobile WebViews), this throws a `SecurityError` that prevents the entire game script from executing. Wrapped the access in a `try-catch` so the game loads gracefully with a high-score default of 0.