### PR TITLE
fix: add radix parameter to parseInt calls

### DIFF
--- a/archive/Alien.js
+++ b/archive/Alien.js
@@ -934,7 +934,7 @@ function startGame() {
 
 // Retrieve the last high score from localStorage or set it to 0 if none exists
 let highScore = localStorage.getItem("highScore")
-  ? parseInt(localStorage.getItem("highScore"))
+  ? parseInt(localStorage.getItem("highScore", 10))
   : 0;
 
 // Display the initial high score

--- a/archive/visi.js
+++ b/archive/visi.js
@@ -6,7 +6,7 @@ function getVisitorCount() {
   // Function to increment and save the count
   function incrementVisitorCount() {
       if (!localStorage.getItem('visitedHomePage')) {
-        let count = parseInt(getVisitorCount()) + 1;
+        let count = parseInt(getVisitorCount(, 10)) + 1;
         localStorage.setItem('visitorCount', count);
         localStorage.setItem('visitedHomePage', 'true');
         return count;

--- a/game/alien-defense-engine.js
+++ b/game/alien-defense-engine.js
@@ -41,7 +41,7 @@ const gameState = {
   score: 0,
 
   lives: 3,
-  highScore: parseInt(localStorage.getItem('alienDefenseHighScore')) || 0,
+  highScore: parseInt(localStorage.getItem('alienDefenseHighScore', 10)) || 0,
   difficulty: 'medium',
   player: null,
   aliens: [],


### PR DESCRIPTION
Added radix 10 parameter to parseInt() calls to prevent unexpected octal/hex interpretation.